### PR TITLE
Set up binding model validation and serialization

### DIFF
--- a/examples/binding_models.py
+++ b/examples/binding_models.py
@@ -49,12 +49,15 @@ def binding_models_answer_ki(
     )
     return [
         CurrentTemperatureBinding(
-            measurement=URIRef("http://example.org/knowledge-mapper/binding-models#currentTemp"),
+            measurement=URIRef(
+                "http://example.org/knowledge-mapper/binding-models#currentTemp"
+            ),
             value=22.5,
             unit=URIRef("http://example.org/knowledge-mapper/binding-models#Celsius"),
             time=datetime.now(),
         )
     ]
+
 
 @kb.answer_ki(
     name="binding-models-raw-answer-ki",
@@ -76,7 +79,7 @@ def binding_models_raw_answer_ki(
     return [
         {
             "measurement": "<http://example.org/knowledge-mapper/binding-models#currentTemp>",
-            "value": 22.5,
+            "value": "'22.5'^^xsd:float",
             "unit": "<http://example.org/knowledge-mapper/binding-models#Celsius>",
             "time": datetime.now().isoformat(),
         }

--- a/examples/binding_models.py
+++ b/examples/binding_models.py
@@ -1,0 +1,92 @@
+from datetime import datetime
+
+from rdflib import URIRef
+from shared import get_example_logger
+
+from src.ke.models import (
+    BindingModel,
+    BindingSet,
+    KnowledgeInteractionInfo,
+    Literal,
+    Uri,
+)
+from src.knowledge_base import KnowledgeBase
+
+EXAMPLE_NAME = "binding-models"
+logger = get_example_logger(EXAMPLE_NAME)
+
+kb = KnowledgeBase(
+    id="http://example.org/knowledge-mapper/binding-models#kb",
+    name="binding-models-kb",
+    description="An example KB that demonstrates the use of binding models.",
+    ke_url="http://localhost:8280/rest",
+)
+
+
+class CurrentTemperatureBinding(BindingModel):
+    measurement: Uri
+    value: Literal[float]
+    unit: Uri
+    time: Literal[datetime]
+
+
+@kb.answer_ki(
+    name="binding-models-answer-ki",
+    graph_pattern="""
+        ?measurement a ex:Measurement ;
+            ex:hasValue ?value ;
+            ex:hasUnit ?unit ;
+            ex:hasTime ?time .
+    """,
+    prefixes={"ex": "http://example.org/knowledge-mapper/binding-models#"},
+)
+def binding_models_answer_ki(
+    binding_set: list[CurrentTemperatureBinding], info: KnowledgeInteractionInfo
+) -> list[CurrentTemperatureBinding]:
+    logger.info(
+        f"Handling a call to the binding models answer KI with incoming bindings: "
+        f"{binding_set}"
+    )
+    return [
+        CurrentTemperatureBinding(
+            measurement=URIRef("http://example.org/knowledge-mapper/binding-models#currentTemp"),
+            value=22.5,
+            unit=URIRef("http://example.org/knowledge-mapper/binding-models#Celsius"),
+            time=datetime.now(),
+        )
+    ]
+
+@kb.answer_ki(
+    name="binding-models-raw-answer-ki",
+    graph_pattern="""
+        ?measurement a ex:Measurement ;
+            ex:hasValue ?value ;
+            ex:hasUnit ?unit ;
+            ex:hasTime ?time .
+    """,
+    prefixes={"ex": "http://example.org/knowledge-mapper/binding-models#"},
+)
+def binding_models_raw_answer_ki(
+    binding_set: BindingSet, info: KnowledgeInteractionInfo
+) -> BindingSet:
+    logger.info(
+        f"Handling a call to the binding models raw answer KI with incoming bindings: "
+        f"{binding_set}"
+    )
+    return [
+        {
+            "measurement": "<http://example.org/knowledge-mapper/binding-models#currentTemp>",
+            "value": 22.5,
+            "unit": "<http://example.org/knowledge-mapper/binding-models#Celsius>",
+            "time": datetime.now().isoformat(),
+        }
+    ]
+
+
+if __name__ == "__main__":
+    kb.connect()
+    kb.register()
+    logger.info("Registered the binding models example KB!")
+
+    kb.unregister()
+    logger.info("Unregistered the binding models example KB!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "pydantic>=2.12.5",
     "pydantic-settings[yaml]>=2.13.1",
+    "rdflib>=7.6.0",
     "requests>=2.32.5",
 ]
 

--- a/src/ke/models.py
+++ b/src/ke/models.py
@@ -1,14 +1,110 @@
+from collections.abc import Sequence
 from enum import StrEnum
-from typing import Annotated
+from typing import Annotated, Any, Self, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    PlainSerializer,
+    PlainValidator,
+)
 from pydantic.alias_generators import to_camel
+from rdflib import Literal as RDFLiteral
+from rdflib import URIRef
+from rdflib.util import from_n3
 
-type BindingSet = list[dict[str, str]]
+type BindingSet = Sequence[dict[str, str]]
+
+# region:    -- Binding Node
+
+
+def validate_uri(input: str | URIRef | None) -> URIRef | None:
+    if isinstance(input, URIRef) or input is None:
+        return input
+    uri = from_n3(input)
+    if not isinstance(uri, URIRef):
+        raise ValueError(f"Expected a URIRef value, got {input}")
+    return uri
+
+
+def serialize_uri(input: URIRef | None) -> str | None:
+    if input is None:
+        return None
+    return input.n3()
+
+
+Uri = Annotated[
+    URIRef | None,
+    PlainValidator(validate_uri),
+    PlainSerializer(serialize_uri),
+    Field(default=None),
+]
+
+
+def serialize_literal(input: Any) -> str | None:
+    if input is None:
+        return None
+    return RDFLiteral(input).n3()
+
+
+def validate_literal(input: Any) -> Any:
+    if isinstance(input, RDFLiteral):
+        return input.toPython()
+    if input is None:
+        return None
+    if not isinstance(input, str) or not (
+        input.startswith('"') or input.startswith("'")
+    ):
+        return input
+
+    literal = from_n3(input)
+    if not isinstance(literal, RDFLiteral):
+        raise ValueError(f"Expected a literal value, got {input}")
+    return literal.toPython()
+
+
+T = TypeVar("T")
+Literal = Annotated[
+    T | None,
+    PlainSerializer(serialize_literal),
+    BeforeValidator(validate_literal),
+    Field(default=None),
+]
+
+# endregion: -- Binding Node
+
+# region:    -- Binding Model
 
 
 class BindingModel(BaseModel):
-    pass
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, alias_generator=to_camel, populate_by_name=True
+    )
+
+    def dump_result_binding(self) -> dict[str, Any]:
+        if any([data is None for _, data in self]):
+            raise ValueError(
+                "Model cannot contain unset fields when dumping to outgoing binding"
+            )
+        return self.model_dump(by_alias=True)
+
+    def dump_partial_binding(self, exclude_none: bool = True) -> dict[str, Any]:
+        return self.model_dump(by_alias=True, exclude_none=exclude_none)
+
+    def matches_with(self, **kwargs) -> bool:
+        for key, other_value in kwargs.items():
+            own_value: BindingNode = getattr(self, key)
+            if own_value is None:
+                continue
+            if own_value.n3() == other_value:
+                continue
+            return False
+        return True
+
+    def matches_with_binding(self, binding: Self) -> bool:
+        return self.matches_with(**binding.model_dump(exclude_none=True))
 
 
 class KnowledgeBaseInfo(BaseModel):

--- a/src/ke/models.py
+++ b/src/ke/models.py
@@ -95,7 +95,7 @@ class BindingModel(BaseModel):
 
     def matches_with(self, **kwargs) -> bool:
         for key, other_value in kwargs.items():
-            own_value: BindingNode = getattr(self, key)
+            own_value = getattr(self, key)
             if own_value is None:
                 continue
             if own_value.n3() == other_value:

--- a/src/knowledge_base.py
+++ b/src/knowledge_base.py
@@ -1,13 +1,15 @@
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from enum import StrEnum
 from functools import wraps
+from typing import Any
 
 from .ke import Client
 from .ke.client import ClientProtocol, PollResult
 from .ke.errors import KnowledgeEngineNotAvailableError
 from .ke.models import (
     AskAnswerInteractionInfo,
+    BindingModel,
     BindingSet,
     KiTypes,
     KnowledgeBaseInfo,
@@ -39,7 +41,7 @@ class KnowledgeBase:
 
     def __init__(self, id: str, name: str, description: str, ke_url: str):
         self.state = KnowledgeBaseState.UNREGISTERED
-        self.ki_registry: dict[str, KnowledgeInteractionContext] = {}
+        self.ki_registry: dict[str, KnowledgeInteractionContext[Any, ...]] = {}
         self.client: ClientProtocol = Client(ke_url)
         self.info = KnowledgeBaseInfo(
             id=id,
@@ -115,7 +117,9 @@ class KnowledgeBase:
         return
 
     def register_ki(
-        self, ki_ctx: KnowledgeInteractionContext, defer_ke_registration: bool = False
+        self,
+        ki_ctx: KnowledgeInteractionContext[Any, ...],
+        defer_ke_registration: bool = False,
     ) -> KnowledgeInteractionInfo:
         """Register a knowledge interaction for this knowledge base at the KE runtime
         and store it in this object's registry of interactions.
@@ -174,14 +178,17 @@ class KnowledgeBase:
         def decorator(func: Handler) -> Handler:
             @wraps(func)
             def wrapper(
-                binding_set: BindingSet, info: KnowledgeInteractionInfo, *args, **kwargs
-            ):
+                binding_set: BindingSet | list[BindingModel],
+                info: KnowledgeInteractionInfo,
+                *args,
+                **kwargs,
+            ) -> BindingSet | Sequence[BindingModel]:
                 return func(binding_set, info, *args, **kwargs)
 
             self.register_ki(
                 KnowledgeInteractionContext(
                     info=info,
-                    handler=func,
+                    handler=wrapper,
                     status=KnowledgeInteractionStatus.UNREGISTERED,
                 ),
                 defer_ke_registration=defer_ke_registration,
@@ -440,15 +447,27 @@ class KnowledgeBase:
         )
         return
 
-    def call(self, binding_set: BindingSet, ki_id: str) -> BindingSet:
-        """Invoke the handler of a registered KI by its ID.
+    def call(
+        self, binding_set: BindingSet, ki_name: str
+    ) -> BindingSet:
+        """Invoke the handler of a registered KI by its name.
 
         Raises:
-            KeyError: If ``ki_id`` is not found in the local KI registry.
+            KeyError: If ``ki_name`` is not found in the local KI registry.
         """
-        ki_ctx = self.ki_registry[ki_id]
-        result = ki_ctx.handler(binding_set, ki_ctx.info)
-        return result
+        ki_ctx = self.ki_registry[ki_name]
+        if ki_ctx.validation_model:
+            binding_models = [
+                ki_ctx.validation_model.model_validate(b) for b in binding_set
+            ]
+            result_bindings = ki_ctx.handler(binding_models, ki_ctx.info)
+        else:
+            result_bindings = ki_ctx.handler(binding_set, ki_ctx.info)
+
+        if ki_ctx.serialization_model and result_bindings:
+            # We can assume the result bindings are BindingModels, so we can model_dump
+            result_bindings = [b.model_dump() for b in result_bindings]  # pyright: ignore[reportAttributeAccessIssue],
+        return result_bindings # pyright: ignore[reportReturnType]
 
     def start_handling_loop(self, loops: int | None = None) -> None:
         """Poll the KE runtime for incoming KI calls and dispatch them to handlers.

--- a/src/knowledge_base.py
+++ b/src/knowledge_base.py
@@ -447,9 +447,7 @@ class KnowledgeBase:
         )
         return
 
-    def call(
-        self, binding_set: BindingSet, ki_name: str
-    ) -> BindingSet:
+    def call(self, binding_set: BindingSet, ki_name: str) -> BindingSet:
         """Invoke the handler of a registered KI by its name.
 
         Raises:
@@ -467,7 +465,7 @@ class KnowledgeBase:
         if ki_ctx.serialization_model and result_bindings:
             # We can assume the result bindings are BindingModels, so we can model_dump
             result_bindings = [b.model_dump() for b in result_bindings]  # pyright: ignore[reportAttributeAccessIssue],
-        return result_bindings # pyright: ignore[reportReturnType]
+        return result_bindings  # pyright: ignore[reportReturnType]
 
     def start_handling_loop(self, loops: int | None = None) -> None:
         """Poll the KE runtime for incoming KI calls and dispatch them to handlers.

--- a/src/knowledge_interaction.py
+++ b/src/knowledge_interaction.py
@@ -1,18 +1,19 @@
 import inspect
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Concatenate
+from typing import Any, Concatenate, get_args
 
-from src.ke.models import BindingSet, KnowledgeInteractionInfo
+from src.ke.models import BindingModel, BindingSet, KnowledgeInteractionInfo
 
-type Handler = Callable[
-    Concatenate[BindingSet, KnowledgeInteractionInfo, ...], BindingSet
+type Handler[B, **P] = Callable[
+    Concatenate[B, KnowledgeInteractionInfo, P],
+    BindingSet | Sequence[BindingModel],
 ]
 
 
 def default_ask_handler(
-    binding_set: BindingSet, info: KnowledgeInteractionInfo
+    binding_set: BindingSet, info: KnowledgeInteractionInfo, keyword: str
 ) -> BindingSet:
     # TODO: Implement a default ASK handler when implementing serialization and
     # validation of binding sets
@@ -23,7 +24,7 @@ def default_ask_handler(
 
 
 def default_post_handler(
-    binding_set: BindingSet, info: KnowledgeInteractionInfo
+    binding_set: BindingSet, info: KnowledgeInteractionInfo, keyword: str
 ) -> BindingSet:
     # TODO: Implement a default POST handler when implementing serialization and
     # validation of binding sets
@@ -39,15 +40,97 @@ class KnowledgeInteractionStatus(StrEnum):
 
 
 @dataclass
-class KnowledgeInteractionContext:
+class KnowledgeInteractionContext[B, **P]:
     info: KnowledgeInteractionInfo
-    handler: Handler
+    handler: Handler[B, P]
     status: KnowledgeInteractionStatus = KnowledgeInteractionStatus.UNREGISTERED
+    validation_model: type[BindingModel] | None = field(init=False, default=None)
+    serialization_model: type[BindingModel] | None = field(init=False, default=None)
 
     def __post_init__(self):
         if not callable(self.handler):
             raise ValueError("Handler must be a callable.")
 
-        sig = inspect.signature(self.handler)
-        if "binding_set" not in sig.parameters:
+        self.validation_model = self._inspect_incoming_binding_model(self.handler)
+        self.serialization_model = self._inspect_outgoing_binding_model(self.handler)
+
+    def _inspect_incoming_binding_model(
+        self, handler: Callable[..., Any]
+    ) -> type[BindingModel] | None:
+        signature = inspect.signature(handler)
+        if "binding_set" not in signature.parameters:
             raise ValueError("Handler must have a 'binding_set' parameter.")
+
+        binding_set_param = signature.parameters["binding_set"]
+        if binding_set_param.annotation is inspect.Parameter.empty:
+            # No incoming binding model is provided, assume a raw BindingSet
+            return None
+
+        err = ValueError(
+            "Handler 'binding_set' parameter must be annotated with BindingSet "
+            "or a Sequence of BindingModels."
+        )
+        annotation = binding_set_param.annotation
+        origin = getattr(annotation, "__origin__", None)
+        if origin is not None and issubclass(origin, Sequence):
+            item_type = get_args(annotation)[0]
+            if not isinstance(item_type, type):
+                # Error if binding_set annotation is a Sequence but item type is not a
+                # class
+                raise err
+
+            if issubclass(item_type, BindingModel):
+                # Incoming binding model is provided
+                return item_type
+            elif isinstance(item_type, dict):
+                # No incoming binding model is provided, just a raw BindingSet
+                return None
+            else:
+                # Error if binding_set annotation is a Sequence but item type is not a
+                # BindingModel or a dict
+                raise err
+        elif origin is None and isinstance(annotation, type):
+            # Error if return type annotation is not a Sequence of BindingModels or a
+            # raw BindingSet
+            raise err
+        else:
+            # No outgoing binding model is provided, just a raw BindingSet
+            return None
+
+    def _inspect_outgoing_binding_model(
+        self, handler: Callable[..., Any]
+    ) -> type[BindingModel] | None:
+        signature = inspect.signature(handler)
+        if signature.return_annotation is inspect.Signature.empty:
+            return None
+
+        err = ValueError(
+            "Handler return type must be annotated with BindingSet or a Sequence of "
+            "BindingModels."
+        )
+        annotation = signature.return_annotation
+        origin = getattr(annotation, "__origin__", None)
+        if origin is not None and issubclass(origin, Sequence):
+            item_type = get_args(annotation)[0]
+            if not isinstance(item_type, type):
+                # Error if return type annotation is a Sequence but item type is not a
+                # class
+                raise err
+
+            if issubclass(item_type, BindingModel):
+                # Outgoing binding model is provided
+                return item_type
+            elif isinstance(item_type, dict):
+                # No outgoing binding model is provided, just a raw BindingSet
+                return None
+            else:
+                # Error if return type annotation is a Sequence but item type is not a
+                # BindingModel or a dict
+                raise err
+        elif origin is None and isinstance(annotation, type):
+            # Error if return type annotation is not a Sequence of BindingModels or a
+            # raw BindingSet
+            raise err
+        else:
+            # No outgoing binding model is provided, just a raw BindingSet
+            return None

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1,0 +1,93 @@
+from rdflib import Literal as RDFLiteral
+from rdflib import URIRef
+
+from src.ke.models import (
+    BindingModel,
+    Literal,
+    Uri,
+    serialize_literal,
+    serialize_uri,
+    validate_literal,
+    validate_uri,
+)
+
+
+def test_validate_str_to_uriref():
+    uri = "<http://example.com/uri>"
+    validated = validate_uri(uri)
+    assert isinstance(validated, URIRef)
+    assert validated.toPython() == "http://example.com/uri"
+
+
+def test_validate_str_to_literal():
+    literal = '"foo"@de'
+    validated = validate_literal(literal)
+    assert isinstance(validated, str)
+    assert validated == "foo"
+
+    literal = '"4"^^xsd:integer'
+    validated = validate_literal(literal)
+    assert isinstance(validated, int)
+    assert validated == 4
+
+
+def test_validate_none():
+    assert validate_literal(None) is None
+
+
+def test_validate_uriref():
+    assert isinstance(validate_uri(URIRef("<URI>")), URIRef)
+
+
+def test_validate_literal():
+    assert isinstance(validate_literal(RDFLiteral("literal")), str)
+
+
+def test_serialize_none():
+    assert serialize_literal(None) is None
+
+
+def test_serialize_uriref():
+    assert serialize_uri(URIRef("uri")) == "<uri>"
+
+
+def test_serialize_literal():
+    assert serialize_literal(RDFLiteral("literal")) == '"literal"'
+
+
+def test_serialize_binding():
+    class TestBinding(BindingModel):
+        sensor: Uri
+        year_of_manufacture: Literal[int]
+        manufacturer_name: Literal[str]
+
+    binding = TestBinding(
+        sensor=URIRef("http://example.org/test#sensor"),
+        year_of_manufacture=2020,
+        manufacturer_name="Manufacturer Inc.",
+    )
+
+    assert binding.dump_result_binding() == {
+        "sensor": "<http://example.org/test#sensor>",
+        "yearOfManufacture": '"2020"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        "manufacturerName": '"Manufacturer Inc."',
+    }
+
+
+def test_validate_binding():
+    class TestBinding(BindingModel):
+        sensor: Uri
+        year_of_manufacture: Literal[int]
+        manufacturer_name: Literal[str]
+
+    binding = TestBinding.model_validate(
+        {
+            "sensor": "<http://example.org/test#sensor>",
+            "yearOfManufacture": '"2020"^^<http://www.w3.org/2001/XMLSchema#integer>',
+            "manufacturerName": '"Manufacturer Inc."',
+        }
+    )
+
+    assert binding.sensor == URIRef("http://example.org/test#sensor")
+    assert binding.year_of_manufacture == 2020
+    assert binding.manufacturer_name == "Manufacturer Inc."

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,92 @@
+import pytest
+from rdflib import URIRef
+
+from src.ke.models import BindingModel, BindingSet, Uri
+from src.knowledge_base import KnowledgeBase
+
+
+@pytest.fixture
+def kb():
+    kb = KnowledgeBase(
+        id="http://example.org/test#kb",
+        name="test-kb",
+        description="A KB for testing.",
+        ke_url="http://fake-ke",
+    )
+
+    return kb
+
+
+def sensor_handler(binding_set, info):
+    SENSORS = [
+        URIRef("http://example.org/test#sensor1"),
+        URIRef("http://example.org/test#sensor2"),
+    ]
+    if binding_set:
+        filtered_sensors = [b["sensor"] for b in binding_set if b["sensor"] in SENSORS]
+    else:
+        filtered_sensors = SENSORS
+    return [{"sensor": sensor} for sensor in filtered_sensors]
+
+
+def test_handler_with_untyped_binding_set(kb: KnowledgeBase):
+    @kb.answer_ki(
+        name="test-untyped-answer-ki",
+        graph_pattern="""
+            ?sensor a ex:Sensor ;
+            """,
+        prefixes={"ex": "http://example.org/test#"},
+    )
+    def test_untyped_answer_ki(binding_set: BindingSet, info) -> BindingSet:
+        SENSORS = [
+            "<http://example.org/test#sensor1>",
+            "<http://example.org/test#sensor2>",
+        ]
+        if binding_set:
+            filtered_sensors = [
+                binding["sensor"]
+                for binding in binding_set
+                if binding["sensor"] in SENSORS
+            ]
+        else:
+            filtered_sensors = SENSORS
+        return [{"sensor": sensor} for sensor in filtered_sensors]
+
+    result = kb.call(
+        [{"sensor": "<http://example.org/test#sensor1>"}], "test-untyped-answer-ki"
+    )
+    assert result == [
+        {"sensor": "<http://example.org/test#sensor1>"},
+    ]
+
+
+def test_handler_with_typed_binding_set(kb: KnowledgeBase):
+    class TestBinding(BindingModel):
+        sensor: Uri
+
+    @kb.answer_ki(
+        name="typed-answer-ki",
+        graph_pattern="""
+            ?sensor a ex:Sensor ;
+            """,
+        prefixes={"ex": "http://example.org/test#"},
+    )
+    def test_answer_ki(binding_set: list[TestBinding], info) -> list[TestBinding]:
+        SENSORS = [
+            URIRef("http://example.org/test#sensor1"),
+            URIRef("http://example.org/test#sensor2"),
+        ]
+        if binding_set:
+            filtered_sensors = [
+                binding.sensor for binding in binding_set if binding.sensor in SENSORS
+            ]
+        else:
+            filtered_sensors = SENSORS
+        return [TestBinding(sensor=sensor) for sensor in filtered_sensors]
+
+    result = kb.call(
+        [{"sensor": "<http://example.org/test#sensor1>"}], "typed-answer-ki"
+    )
+    assert result == [
+        {"sensor": "<http://example.org/test#sensor1>"},
+    ]

--- a/tests/test_ki_registration.py
+++ b/tests/test_ki_registration.py
@@ -33,6 +33,9 @@ def shared_prefixes():
 
 
 def ki_ctx_setup() -> KnowledgeInteractionContext:
+    def handler(binding_set: BindingSet, info: KnowledgeInteractionInfo) -> BindingSet:
+        return binding_set
+
     return KnowledgeInteractionContext(
         info=AskAnswerInteractionInfo(
             name="test-ki",
@@ -40,7 +43,7 @@ def ki_ctx_setup() -> KnowledgeInteractionContext:
             graph_pattern="""?s ?p ?o . """,
             prefixes=shared_prefixes(),
         ),
-        handler=lambda binding_set, info: binding_set,
+        handler=handler,
         status=KnowledgeInteractionStatus.UNREGISTERED,
     )
 
@@ -233,5 +236,5 @@ def test_call_handler():
 
     ki_info = next(iter(kb.ki_registry.values())).info
     input_binding_set = [{"input": "test:Input1", "value": "Hello"}]
-    result = kb.call(binding_set=input_binding_set, ki_id=ki_info.name)
+    result = kb.call(binding_set=input_binding_set, ki_name=ki_info.name)
     assert result == input_binding_set

--- a/uv.lock
+++ b/uv.lock
@@ -111,6 +111,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings", extra = ["yaml"] },
+    { name = "rdflib" },
     { name = "requests" },
 ]
 
@@ -124,6 +125,7 @@ dev = [
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.13.1" },
+    { name = "rdflib", specifier = ">=7.6.0" },
     { name = "requests", specifier = ">=2.32.5" },
 ]
 
@@ -248,6 +250,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -306,6 +317,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rdflib"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/18bb77b7af9526add0c727a3b2048959847dc5fb030913e2918bf384fec3/rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df", size = 4943826, upload-time = "2026-02-13T07:15:55.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c2/6604a71269e0c1bd75656d5a001432d16f2cc5b8c057140ec797155c295e/rdflib-7.6.0-py3-none-any.whl", hash = "sha256:30c0a3ebf4c0e09215f066be7246794b6492e054e782d7ac2a34c9f70a15e0dd", size = 615416, upload-time = "2026-02-13T07:15:46.487Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Solves #8 
Implements binding models that use pydantic and rdflib to serialize and deserialize binding sets and python objects.
Handler functions can use these in the function signature, and input is than automatically serialized to that binding model.
This is not required, using just a BindingSet/list[dict] in the function signature is accepted as well (see example).