### PR TITLE
Add support for optional result pattern and empty binding sets

### DIFF
--- a/src/knowledge_mapper/kb/knowledge_base.py
+++ b/src/knowledge_mapper/kb/knowledge_base.py
@@ -440,7 +440,7 @@ class KnowledgeBase:
         self,
         name: str,
         argument_graph_pattern: str,
-        result_graph_pattern: str,
+        result_graph_pattern: str | None = None,
         argument_binding_model: type[BindingModel] | None = None,
         result_binding_model: type[BindingModel] | None = None,
         prefixes: dict | None = None,
@@ -478,7 +478,7 @@ class KnowledgeBase:
         self,
         name: str,
         argument_graph_pattern: str,
-        result_graph_pattern: str,
+        result_graph_pattern: str | None = None,
         prefixes: dict | None = None,
         defer_ke_registration: bool = True,
     ) -> Callable[[Handler], Handler]:

--- a/src/knowledge_mapper/ke/models.py
+++ b/src/knowledge_mapper/ke/models.py
@@ -18,6 +18,8 @@ from rdflib.util import from_n3
 
 type BindingSet = Sequence[dict[str, str]]
 
+EMPTY_BINDING_SET: BindingSet = []
+
 # region:    -- Binding Node
 
 
@@ -155,7 +157,7 @@ class AskAnswerInteractionInfo(KnowledgeInteractionInfo):
 
 class PostReactInteractionInfo(KnowledgeInteractionInfo):
     argument_graph_pattern: str
-    result_graph_pattern: str
+    result_graph_pattern: str | None = None
 
 
 class Initiator(StrEnum):


### PR DESCRIPTION
Closes #5 

Adds also a `EMPTY_BINDING_SET` constant for users to indicate in a react handler that they return an empty set.